### PR TITLE
Add auto option for existing_network_spacing

### DIFF
--- a/growbikenet/functions.py
+++ b/growbikenet/functions.py
@@ -77,8 +77,8 @@ def validate_parameters(
         raise ValueError("seed_point_linking must be 'auto' or 'triangulate_delaunay' or 'quadrangulate'")
     if seed_point_linking == 'quadrangulate' and (seed_point_type != 'grid_square' or existing_network_spacing is not None):
         raise ValueError("With seed_point_linking 'quadrangulate', seed_point_type must be set to 'grid_square' and existing_network_spacing must be set to None")
-    if type(existing_network_spacing) is not int and existing_network_spacing is not None:
-        raise TypeError("existing_network_spacing must be None or a positive integer")
+    if type(existing_network_spacing) is not int and existing_network_spacing is not None and existing_network_spacing != 'auto':
+        raise TypeError("existing_network_spacing must be None or 'auto' or a positive integer")
     if type(existing_network_spacing) is int and existing_network_spacing <= 0:
         raise ValueError("existing_network_spacing must be None or a positive integer")
     if type(existing_network_spacing) is int and seed_point_grid_spacing is int and existing_network_spacing >= seed_point_grid_spacing:
@@ -210,6 +210,9 @@ def resolve_auto_parameters(
 
     if seed_point_delta == 'auto':
         seed_point_delta = int(np.ceil(seed_point_grid_spacing/4))
+
+    if existing_network_spacing == 'auto':
+        existing_network_spacing = int(np.ceil(seed_point_grid_spacing/2))
 
     return seed_point_type, seed_point_grid_spacing, seed_point_delta, seed_point_linking, existing_network_spacing
 

--- a/growbikenet/growbikenet.py
+++ b/growbikenet/growbikenet.py
@@ -90,8 +90,8 @@ def growbikenet(
         If set to 'auto', selects 'triangulate_delaunay' or 'quadrangulate' automatically depending on the street network's orientation entropy, see [3]_.
         If set to 'triangulate_delaunay', uses Delaunay triangulation.
         If set to 'quadrangulate', uses quadrangulation, which only works for seed_point_type 'grid_square' and existing_network_spacing None. Useful for grid-like street networks like Manhattan or Barcelona.
-    existing_network_spacing : int, default None
-        Spacing between seed points, in meters, only on the existing bicycle network. If not set to a positive integer, the existing network is ignored. existing_network_spacing is recommended to be smaller than seed_point_grid_spacing, ideally around 25%, to ensure that the existing bicycle network is built first.
+    existing_network_spacing : None | 'auto' | int, default None
+        Spacing between seed points, in meters, only on the existing bicycle network. If not set to a positive integer, the existing network is ignored. existing_network_spacing is recommended to be smaller than seed_point_grid_spacing, ideally around 50%, to ensure that the existing bicycle network is built first. Option 'auto' sets existing_network_spacing to 50% of the seed_point_grid_spacing.
     export_data : bool, default True
         If set to True, data is saved to a file. The filename is [slug]-[ranking]-[seed_point_type].[export_file_format], where slug is a string id made out of city_name.
     export_file_format : str ('geojson' | 'gpkg'), default 'geojson'


### PR DESCRIPTION
## Description

Add auto option for existing_network_spacing

## Related Issue

Fixes #179 

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [X] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🧹 Code refactor (no functional changes)
- [ ] ✅ Test update

## How Has This Been Tested?

pytest
- [ ] Unit tests
- [ ] Integration tests
- [ ] Manual testing

**Test configuration:**  
- OS:

## Screenshots (if applicable)



## Checklist

all applicable
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have updated the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally


## Additional Notes

