### PR TITLE
docs: set nbsphinx_widgets_path for interactive Jupyter widgets

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -46,6 +46,7 @@ extensions = [
 ]
 
 nbsphinx_allow_errors = True # Remove once growbikenet is v1
+nbsphinx_widgets_path = "_static/widgets"
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 


### PR DESCRIPTION
Fixes #168

Add nbsphinx widget state output path so Jupyter widgets render interactively in the built docs.

Could not run the suite locally: . Fork CI needs a maintainer approval to run, so this branch has no test signal yet.

---
This change was prepared with AI assistance under human direction and review.